### PR TITLE
feat: upgrade to images of version 1 (rolling tag)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM unityci/editor:2019.2.11f1-base-0
+FROM unityci/editor:ubuntu-2019.2.11f1-base-1
 
 LABEL "com.github.actions.name"="Unity - Return License"
 LABEL "com.github.actions.description"="Return a Unity Pro license and free up a spot towards the maximum number of active licenses."


### PR DESCRIPTION
#### Changes

- Switch reference to docker images to use rolling version `1` instead of `0`, so it will use `1.x.x` images from [docker](https://github.com/game-ci/docker) ([versions](https://game.ci/docs/docker/versions))
- Change to more specific prefix: Linux base platform now uses `ubuntu-` prefix instead of relying on that all images are Ubuntu-based.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
